### PR TITLE
bugfix setter of light.saturation and light.brightness

### DIFF
--- a/lib/hue/light.rb
+++ b/lib/hue/light.rb
@@ -180,7 +180,7 @@ module Hue
     def translate_keys(hash)
       new_hash = {}
       hash.each do |key, value|
-        new_key = KEYS_MAP[key.to_sym]
+        new_key = STATE_KEYS_MAP[key.to_sym]
         key = new_key if new_key
         new_hash[key] = value
       end


### PR DESCRIPTION
Hi, thank you for a great gem.

I have found a bug and fixed it.
### bug

following code sets random values to hue, but `saturation` and `brightness` are not worked.

``` ruby
require 'hue'

hue = Hue::Client.new
hue.lights.each do |light|
  light.on = true
end

loop do
  hue.lights.each do |light|
    puts light.name
    light.hue = rand 65535
    light.saturation = rand 255  ## not work
    light.brightness = rand 255  ## not work
  end
  sleep 0.1
end
```

they got error messages from hue bridge.

```
"[{\"error\":{\"type\":6,\"address\":\"/lights/1/state/brightness\",\"description\":\"parameter, brightness, not available\"}}]"
"[{\"error\":{\"type\":6,\"address\":\"/lights/2/state/saturation\",\"description\":\"parameter, saturation, not available\"}}]"
```
### fixed

use `STATE_KEYS_MAP` instead of `KEYS_MAP` in translate_keys function.
