### PR TITLE
Light related methods is moved from Client class to Bridge class.

### DIFF
--- a/lib/hue/bridge.rb
+++ b/lib/hue/bridge.rb
@@ -68,6 +68,22 @@ module Hue
       unpack(json)
     end
 
+    def lights
+      @lights ||= begin
+        json = MultiJson.load(Net::HTTP.get(URI.parse("http://#{ip}/api/#{@client.username}")))
+        json['lights'].map do |key, value|
+          Light.new(@client, self, key, value)
+        end
+      end
+    end
+
+    def add_lights
+      uri = URI.parse("http://#{ip}/api/#{@client.username}/lights")
+      http = Net::HTTP.new(uri.host)
+      response = http.request_post(uri.path, nil)
+      MultiJson.load(response.body).first
+    end
+
   private
 
     KEYS_MAP = {

--- a/lib/hue/client.rb
+++ b/lib/hue/client.rb
@@ -32,21 +32,11 @@ module Hue
     end
 
     def lights
-      @lights ||= begin
-        ls = []
-        json = MultiJson.load(Net::HTTP.get(URI.parse("http://#{bridge.ip}/api/#{@username}")))
-        json['lights'].each do |key, value|
-          ls << Light.new(self, bridge, key, value)
-        end
-        ls
-      end
+      bridge.lights
     end
 
     def add_lights
-      uri = URI.parse("http://#{bridge.ip}/api/#{@username}/lights")
-      http = Net::HTTP.new(uri.host)
-      response = http.request_post(uri.path, nil)
-      MultiJson.load(response.body).first
+      bridge.add_lights
     end
 
     def light(id)


### PR DESCRIPTION
The light of all the bridges can be operated as follows.

``` ruby
require 'hue'
client = Hue::Client.new

lights = client.bridges.map { |bridge| bridge.lights }.flatten

lights.each do |light|
  light.on = true
  light.saturation = 180
  light.brightness = 200
  light.hue = 14922
end
```
