### PR TITLE
Update meethue nupnp url to https

### DIFF
--- a/lib/hue/client.rb
+++ b/lib/hue/client.rb
@@ -24,7 +24,7 @@ module Hue
     def bridges
       @bridges ||= begin
         bs = []
-        MultiJson.load(Net::HTTP.get(URI.parse('http://www.meethue.com/api/nupnp'))).each do |hash|
+        MultiJson.load(Net::HTTP.get(URI.parse('https://www.meethue.com/api/nupnp'))).each do |hash|
           bs << Bridge.new(self, hash)
         end
         bs


### PR DESCRIPTION
Endpoint no longer works over plain http. Gem throws a json parse error.
