### PR TITLE
Follow Redirects

### DIFF
--- a/lib/hue.rb
+++ b/lib/hue.rb
@@ -1,6 +1,7 @@
 require 'hue/version'
 require 'hue/errors'
 require 'hue/client'
+require 'hue/http'
 require 'hue/bridge'
 require 'hue/light'
 

--- a/lib/hue/client.rb
+++ b/lib/hue/client.rb
@@ -24,7 +24,7 @@ module Hue
     def bridges
       @bridges ||= begin
         bs = []
-        MultiJson.load(Net::HTTP.get(URI.parse('http://www.meethue.com/api/nupnp'))).each do |hash|
+        MultiJson.load(Hue::HTTP.new('http://www.meethue.com/api/nupnp').fetch).each do |hash|
           bs << Bridge.new(self, hash)
         end
         bs

--- a/lib/hue/http.rb
+++ b/lib/hue/http.rb
@@ -1,0 +1,40 @@
+require 'net/http'
+
+module Hue
+  class HTTP
+
+    class TooManyRedirects < Error; end
+
+    def initialize(uri_string)
+      @uri = URI.parse(uri_string)
+    end
+
+    def fetch(limit = 10)
+      raise TooManyRedirects if limit == 0
+
+      http = Net::HTTP.new(uri.host, uri_port)
+      http.use_ssl = use_ssl?
+      response = http.get2(uri.path)
+
+      case response
+      when Net::HTTPSuccess then response.body
+      when Net::HTTPRedirection
+        @uri = URI.parse(response['location'])
+        fetch(limit - 1)
+      end
+    end
+
+  private
+
+    attr_reader :uri
+
+    def use_ssl?
+      uri.scheme == 'https'
+    end
+
+    def uri_port
+      use_ssl? ? 443 : 80
+    end
+
+  end
+end


### PR DESCRIPTION
http://www.meethue.com/api/nupnp now redirects to https://www.meethue.com/api/nupnp.

the bridge finder endpoint now redirects to a https version of itself.
There is no built in way to follow redirects using ruby libraries so i
implemented redirection based heavily on
http://ruby-doc.org/stdlib-2.1.2/libdoc/net/http/rdoc/Net/HTTP.html#class-Net::HTTP-label-Following+Redirection

essentially, this change will hit the http endpoint, and then follow it
to the https endpoint to resolve the bridge's local ip on the network.

This could have much more easily been implemented with:
`MultiJson.load(`curl -Ls http://www.meethue.com/api/nupnp`)` but i
didn’t want to rely on the local environment having curl available.

Im really keen on getting this (or a fix for this issue) in, so please let me know what you think.
