### PR TITLE
add "--brightness" and "--saturation" alias for hue CLI

### DIFF
--- a/lib/hue/cli.rb
+++ b/lib/hue/cli.rb
@@ -34,8 +34,8 @@ module Hue
       hue light 1 off
     LONGDESC
     option :hue, :type => :numeric
-    option :sat, :type => :numeric
-    option :bri, :type => :numeric
+    option :sat, :type => :numeric, :aliases => '--saturation'
+    option :bri, :type => :numeric, :aliases => '--brightness'
     option :alert, :type => :string
     def light(id, state = nil)
       light = client.light(id)


### PR DESCRIPTION
I've added `--brightness` and `--saturation` options as aliases for `--bri` and `--sat`, because `Readme.markdown` using `--brightness`.

```
$ hue light 2 --brightness 20
$ hue light 3 --saturation 200
```

It works.

![image](https://cloud.githubusercontent.com/assets/34204/4098473/188acba8-3023-11e4-9c4a-fb97b294fde0.png)
