### PR TITLE
Update Readme.markdown: incorrect transition time parameter example.

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -45,7 +45,7 @@ From Ruby:
 > light.on = true
 > light.hue = 46920
 > light.color_temperature = 100
-> light.set_state({:color_temperature => 400}, transition=10*5) # Transit to 400K in 5 seconds.
+> light.set_state({:color_temperature => 400}, 10*5) # Transit to color temp 400 in 5 seconds.
 ```
 
 ## Contributing


### PR DESCRIPTION
Correct usage of transition time for the light#set_state method.
