### PR TITLE
Add local UPnP support

### DIFF
--- a/Todo.markdown
+++ b/Todo.markdown
@@ -7,4 +7,3 @@
 * Effects
 * User management
 * Configuration
-* Local UPNP

--- a/hue.gemspec
+++ b/hue.gemspec
@@ -18,7 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 1.8.7'
+  spec.required_ruby_version = '>= 1.9.3'
   spec.add_dependency 'thor'
   spec.add_dependency 'json'
+  spec.add_dependency 'log_switch', '0.4.0'
+  spec.add_dependency 'playful'
 end


### PR DESCRIPTION
Searches for the hue bridge using local UPnP instead of requiring an internet connection to query the N-UPnP service. In the event that the bridge cannot be found using UPnP, it will use the N-UPnP service like before.