### PR TITLE
add spec tasks to Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,10 @@
 require 'bundler/gem_tasks'
+
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+
+  task :default => :spec
+rescue LoadError
+  # no rspec available
+end


### PR DESCRIPTION
Adds `rake spec` task and makes `rake` default to `rake spec` when RSpec is available