### PR TITLE
Added fields to hue lights command and table format

### DIFF
--- a/hue.gemspec
+++ b/hue.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'json'
   spec.add_dependency 'log_switch', '0.4.0'
   spec.add_dependency 'curb'
+  spec.add_dependency 'terminal-table'
   spec.add_development_dependency 'rspec', '~> 3.2.0'
   spec.add_development_dependency 'webmock'
 end

--- a/lib/hue/cli.rb
+++ b/lib/hue/cli.rb
@@ -1,12 +1,16 @@
 require 'thor'
+require 'terminal-table'
 
 module Hue
   class Cli < Thor
     desc 'lights', 'Find all of the lights on your network'
     def lights
-      client.lights.each do |light|
-        puts light.id.to_s.ljust(6) + light.name
+      headings = ["ID", "Name", "Status", "Hue", "Saturation", "Brightness"]
+      rows = client.lights.each_with_object([]) do |light, r|
+        status = light.off? ? "OFF" : "ON"
+        r << [light.id, light.name, status, light.hue, light.saturation, light.brightness]
       end
+      puts Terminal::Table.new(rows: rows, headings: headings)
     end
 
     desc 'add LIGHTS', 'Search for new lights'

--- a/lib/hue/light.rb
+++ b/lib/hue/light.rb
@@ -140,6 +140,10 @@ module Hue
       unpack(json)
     end
 
+    def off?
+      !@state["on"]
+    end
+
   private
 
     KEYS_MAP = {

--- a/spec/hue/light_spec.rb
+++ b/spec/hue/light_spec.rb
@@ -9,16 +9,33 @@ RSpec.describe Hue::Light do
 
       stub_request(:put, %r{http://localhost/api*}).
         to_return(:body => '[{}]')
+
+      @client = Hue::Client.new
     end
 
     describe "##{attribute}=" do
       it "PUTs the new attribute value" do
-        client = Hue::Client.new
-        light = Hue::Light.new(client, client.bridge, 0, {"state" => {}})
+        light = Hue::Light.new(@client, @client.bridge, 0, {"state" => {}})
 
         light.send("#{attribute}=", 24)
         expect(a_request(:put, %r{http://localhost/api/.*/lights/0})).to have_been_made
       end
+    end
+  end
+
+  describe "#off?" do
+    it "should return the opposite of state['on']" do
+      state = {'on' => true}
+      light = Hue::Light.new(@client, @client.bridge, 0, "state" => state)
+      expect(light.off?).to be false
+
+      state = {}
+      light = Hue::Light.new(@client, @client.bridge, 0, "state" => state)
+      expect(light.off?).to be true
+
+      state = {'off' => false}
+      light = Hue::Light.new(@client, @client.bridge, 0, "state" => state)
+      expect(light.off?).to be true
     end
   end
 end


### PR DESCRIPTION
Added some new fields to the `hue lights` command. Also, formatted the output using a table format gem.
```
$ hue lights
+----+-------------+--------+-------+------------+------------+
| ID | Name        | Status | Hue   | Saturation | Brightness |
+----+-------------+--------+-------+------------+------------+
| 1  | Living Room | ON     | 13088 | 213        | 110        |
| 2  | Bedroom 1   | ON     | 13088 | 213        | 110        |
| 3  | Bedroom 2   | ON     | 13088 | 213        | 110        |
| 4  | Kitchen     | ON     |       |            | 224        |
+----+-------------+--------+-------+------------+------------+
```