### PR TITLE
Adding travis configuration and badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: ruby

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -2,7 +2,10 @@
 
 Work with Philips Hue light bulbs from Ruby.
 
-[![Code Climate](https://codeclimate.com/github/soffes/hue.png)](https://codeclimate.com/github/soffes/hue) [![Dependency Status](https://gemnasium.com/soffes/hue.png)](https://gemnasium.com/soffes/hue) [![Gem Version](https://badge.fury.io/rb/hue.png)](http://badge.fury.io/rb/hue)
+[![Code Climate](https://codeclimate.com/github/soffes/hue.png)](https://codeclimate.com/github/soffes/hue)
+[![Dependency Status](https://gemnasium.com/soffes/hue.png)](https://gemnasium.com/soffes/hue)
+[![Gem Version](https://badge.fury.io/rb/hue.png)](http://badge.fury.io/rb/hue)
+[![Build Status](https://travis-ci.org/soffes/hue.svg)](https://travis-ci.org/soffes/hue)
 
 ## Installation
 


### PR DESCRIPTION
This should add Travis to this project which will run tests for each pull request and merge. There'll also be a badge to show the current status of the project. To complete the Travis setup:

1. Login at travis-ci.org and go to https://travis-ci.org/profile/soffes
2. Click the checkbox next to soffes/hue to enable.
3. Back at github, visit the settings for soffes/hue and click on the "Webhooks & Services" link on the left.
4. Click on "Add Service" and select Travis. Leave the fields blank. I think Travis will populate them.

I think this should do it. It's hard to tell without actually setting it up. Let me know if you need help.
