### PR TITLE
Clear out stored data after refreshing bridge.

### DIFF
--- a/lib/hue/bridge.rb
+++ b/lib/hue/bridge.rb
@@ -66,6 +66,9 @@ module Hue
     def refresh
       json = get_configuration
       unpack(json)
+      @lights = nil
+      @groups = nil
+      @scenes = nil
     end
 
     def lights


### PR DESCRIPTION
This clears out the stored state of lights, groups, and scenes when doing a refresh on the bridge.

This might be naive on my part, since refresh mainly updates metadata for the bridge. But I'm not sure why you'd really care about doing that anyways (hence my naiveté). So in addition to refreshing metadata, it forces a refresh of all state.

This resolves #39.