### PR TITLE
Handle username argument correctly

### DIFF
--- a/lib/hue/client.rb
+++ b/lib/hue/client.rb
@@ -7,9 +7,7 @@ module Hue
     attr_reader :username
 
     def initialize(username = nil)
-      username = find_username unless username
-
-      @username = username
+      @username = username || find_username
 
       if @username
         begin


### PR DESCRIPTION
```ruby
Hue::Client.new("username_string") #=> "user_name_string" is ignored
```

I couldn't run RSpec with webmock issue, so this PR is not including tests for changes 🕶 