### PR TITLE
fix cli brightness alias for light and group command

### DIFF
--- a/lib/hue/cli.rb
+++ b/lib/hue/cli.rb
@@ -50,7 +50,7 @@ module Hue
     LONGDESC
     option :hue, :type => :numeric
     option :sat, :type => :numeric, :aliases => '--saturation'
-    option :brightness, :type => :numeric, :aliases => '--brightness'
+    option :bri, :type => :numeric, :aliases => '--brightness'
     option :alert, :type => :string
     def light(id, state = nil)
       light = client.light(id)
@@ -81,7 +81,7 @@ module Hue
     LONGDESC
     option :hue, :type => :numeric
     option :sat, :type => :numeric, :aliases => '--saturation'
-    option :brightness, :type => :numeric, :aliases => '--brightness'
+    option :bri, :type => :numeric, :aliases => '--brightness'
     option :alert, :type => :string
     def group(id, state = nil)
       group = client.group(id)


### PR DESCRIPTION
Currently the only possibility to set the brightness is via the `--brightness` option.  As mentioned in the examples from `hue help light` it should be possible to specify the brightness via the `--bri` option/alias.

```
$ hue help light
Usage:
  hue light ID STATE [COLOR]

Options:
      [--hue=N]
  --saturation, [--sat=N]
  --brightness, [--brightness=N]
      [--alert=ALERT]

Description:
  Examples:

  hue light 1 on --hue 12345

  hue light 1 --bri 25

  hue light 1 --alert lselect

  hue light 1 off
```

The `hue light` and the `hue group` command doesn't accept the `--bri` option:

```
$ hue light 7 --bri 100
ERROR: "hue light" was called with arguments ["7", "--bri", "100"]
Usage: "hue light ID STATE [COLOR]"
```

So I renamed the options to match the expected behavior mentioned in the help.
