### PR TITLE
switch to new (still active) discovery URL

### DIFF
--- a/lib/hue/client.rb
+++ b/lib/hue/client.rb
@@ -38,7 +38,7 @@ module Hue
         easy = Curl::Easy.new
         easy.follow_location = true
         easy.max_redirects = 10
-        easy.url = 'https://www.meethue.com/api/nupnp'
+        easy.url = 'https://discovery.meethue.com/'
         easy.perform
         JSON(easy.body).each do |hash|
           bs << Bridge.new(self, hash)

--- a/test/hue/client_test.rb
+++ b/test/hue/client_test.rb
@@ -4,7 +4,7 @@ class ClientTest < Minitest::Test
   def before_setup
     super
 
-    stub_request(:get, "https://www.meethue.com/api/nupnp").
+    stub_request(:get, "https://discovery.meethue.com/").
       to_return(:body => '[{"id":"ffa57b3b257200065704","internalipaddress":"192.168.0.1"},{"id":"63c2fc01391276a319f9","internalipaddress":"192.168.0.2"}]')
 
     stub_request(:get, %r{http://192.168.0.1/api/*}).to_return(:body => '[{"success":true}]')

--- a/test/hue/light_test.rb
+++ b/test/hue/light_test.rb
@@ -4,7 +4,7 @@ class LightTest < Minitest::Test
   def before_setup
     super
 
-    stub_request(:get, "https://www.meethue.com/api/nupnp").
+    stub_request(:get, "https://discovery.meethue.com/").
       to_return(:body => '[{"internalipaddress":"localhost"}]')
 
     stub_request(:get, %r{http://localhost/api/*}).to_return(:body => '[{"success":true}]')


### PR DESCRIPTION
Hi,

The old nupnp URL seems to have been turned off in the last few days; we're apparently supposed to be using this new URL for that purpose now.

Thanks for checking this PR out (and for your lib, which I use literally every day!).