### PR TITLE
Implement mDNS discovery and use as default

### DIFF
--- a/hue.gemspec
+++ b/hue.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.1.0'
   spec.add_dependency 'thor'
   spec.add_dependency 'json'
   spec.add_dependency 'log_switch', '0.4.0'

--- a/test/hue/client_test.rb
+++ b/test/hue/client_test.rb
@@ -12,14 +12,14 @@ class ClientTest < Minitest::Test
   end
 
   def test_with_bridge_id
-    client = Hue::Client.new
+    client = Hue::Client.new(use_mdns: false)
     client.stub :find_bridge_id, '63c2fc01391276a319f9' do
       assert_equal '63c2fc01391276a319f9', client.bridge.id
     end
   end
 
   def test_without_bridge_id
-    client = Hue::Client.new
+    client = Hue::Client.new(use_mdns: false)
     assert_equal 'ffa57b3b257200065704', client.bridge.id
   end
 end

--- a/test/hue/light_test.rb
+++ b/test/hue/light_test.rb
@@ -14,7 +14,7 @@ class LightTest < Minitest::Test
 
   %w{on hue saturation brightness color_temperature alert effect}.each do |attribute|
     define_method "test_setting_#{attribute}" do
-      client = Hue::Client.new
+      client = Hue::Client.new(use_mdns: false)
       light = Hue::Light.new(client, client.bridge, 0, {"state" => {}})
 
       light.send("#{attribute}=", 24)


### PR DESCRIPTION
On the Hue Bridge developer documentation, the mDNS method is listed first, and mentioned to have replaced the old UPnP approach.

https://developers.meethue.com/develop/application-design-guidance/hue-bridge-discovery/

I implemented it using Ruby’s stdlib mDNS resolver. Since it got added in version 2.1.0, I bumped the minimum version to that one.

I think this method is preferable as a default, because it does not need internet connectivity to discover Hue bridges on a local network, and is not subject to rate limiting or temporary or permanent outage of the online API.

The old method is still available as a fallback after a 10 seconds timeout, for example if the user’s router blocks multicast messages. The mDNS discovery can be completely bypassed by passing `use_mdns: false` to the Client initializer.