### PR TITLE
Remove curb dependency

### DIFF
--- a/hue.gemspec
+++ b/hue.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor'
   spec.add_dependency 'json'
   spec.add_dependency 'log_switch', '0.4.0'
-  spec.add_dependency 'curb'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'webmock'
 end

--- a/lib/hue/client.rb
+++ b/lib/hue/client.rb
@@ -1,7 +1,6 @@
 require 'net/http'
 require 'json'
 require 'resolv'
-require 'curb'
 
 module Hue
   class Client
@@ -145,12 +144,10 @@ module Hue
     end
 
     def discovery_meethue(bs)
-      easy = Curl::Easy.new
-      easy.follow_location = true
-      easy.max_redirects = 10
-      easy.url = 'https://discovery.meethue.com/'
-      easy.perform
-      JSON(easy.body).each do |hash|
+      uri = URI('https://discovery.meethue.com/')
+      response = Net::HTTP.get(uri)
+      
+      JSON(response).each do |hash|
         bs << Bridge.new(self, hash)
       end
     end


### PR DESCRIPTION
I can’t get curb to work on Windows for supported versions of Ruby, and according to the project’s [readme](https://github.com/taf2/curb#installation) it seems to be generally unsupported for that platform, which in turn makes Hue difficult to run on Windows.

I don’t know if there was a specific reason why curb is being used rather than Ruby’s standard library HTTP requests, but I’ve tested it out and it seems to work fine.