### PR TITLE
Changed all HTTP calls to HTTPS for Hue Bridge Pro compatibility

### DIFF
--- a/lib/hue.rb
+++ b/lib/hue.rb
@@ -1,5 +1,6 @@
 require "hue/version"
 require "hue/errors"
+require "hue/http_client"
 require "hue/client"
 require "hue/bridge"
 require "hue/editable_state"

--- a/lib/hue/bridge.rb
+++ b/lib/hue/bridge.rb
@@ -73,7 +73,9 @@ module Hue
 
     def lights
       @lights ||= begin
-        json = JSON(Net::HTTP.get(URI.parse(base_url)))
+        uri = URI.parse(base_url)
+        http = HttpClient.create(uri)
+        json = JSON(http.get(uri.path).body)
         json["lights"].map do |key, value|
           Light.new(@client, self, key, value)
         end
@@ -82,14 +84,16 @@ module Hue
 
     def add_lights
       uri = URI.parse("#{base_url}/lights")
-      http = Net::HTTP.new(uri.host)
+      http = HttpClient.create(uri)
       response = http.request_post(uri.path, nil)
       response.body.first
     end
 
     def groups
       @groups ||= begin
-        json = JSON(Net::HTTP.get(URI.parse("#{base_url}/groups")))
+        uri = URI.parse("#{base_url}/groups")
+        http = HttpClient.create(uri)
+        json = JSON(http.get(uri.path).body)
         json.map do |id, data|
           Group.new(@client, self, id, data)
         end
@@ -98,7 +102,9 @@ module Hue
 
     def scenes
       @scenes ||= begin
-        json = JSON(Net::HTTP.get(URI.parse("#{base_url}/scenes")))
+        uri = URI.parse("#{base_url}/scenes")
+        http = HttpClient.create(uri)
+        json = JSON(http.get(uri.path).body)
         json.map do |id, data|
           Scene.new(@client, self, id, data)
         end
@@ -130,11 +136,13 @@ module Hue
     end
 
     def get_configuration
-      JSON(Net::HTTP.get(URI.parse("#{base_url}/config")))
+      uri = URI.parse("#{base_url}/config")
+      http = HttpClient.create(uri)
+      JSON(http.get(uri.path).body)
     end
 
     def base_url
-      "http://#{ip}/api/#{@client.username}"
+      "https://#{ip}/api/#{@client.username}"
     end
   end
 end

--- a/lib/hue/client.rb
+++ b/lib/hue/client.rb
@@ -1,4 +1,5 @@
 require "net/http"
+require "openssl"
 require "json"
 require "resolv"
 
@@ -87,7 +88,9 @@ module Hue
     end
 
     def validate_user
-      response = JSON(Net::HTTP.get(URI.parse("http://#{bridge.ip}/api/#{@username}")))
+      uri = URI.parse("https://#{bridge.ip}/api/#{@username}")
+      http = HttpClient.create(uri)
+      response = JSON(http.get(uri.path).body)
 
       if response.is_a? Array
         response = response.first
@@ -105,8 +108,8 @@ module Hue
         devicetype: "Ruby"
       })
 
-      uri = URI.parse("http://#{bridge.ip}/api")
-      http = Net::HTTP.new(uri.host)
+      uri = URI.parse("https://#{bridge.ip}/api")
+      http = HttpClient.create(uri)
       response = JSON(http.request_post(uri.path, body).body).first
 
       if (error = response["error"])

--- a/lib/hue/group.rb
+++ b/lib/hue/group.rb
@@ -95,7 +95,7 @@ module Hue
       body = translate_keys(attributes, GROUP_KEYS_MAP)
 
       uri = URI.parse(base_url)
-      http = Net::HTTP.new(uri.host)
+      http = HttpClient.create(uri)
       response = http.request_put(uri.path, JSON.dump(body))
       JSON(response.body)
     end
@@ -105,13 +105,15 @@ module Hue
       body = translate_keys(attributes, STATE_KEYS_MAP)
 
       uri = URI.parse("#{base_url}/action")
-      http = Net::HTTP.new(uri.host)
+      http = HttpClient.create(uri)
       response = http.request_put(uri.path, JSON.dump(body))
       JSON(response.body)
     end
 
     def refresh
-      json = JSON(Net::HTTP.get(URI.parse(base_url)))
+      uri = URI.parse(base_url)
+      http = HttpClient.create(uri)
+      json = JSON(http.get(uri.path).body)
       unpack(json)
       @lights = nil
     end
@@ -122,8 +124,8 @@ module Hue
         lights: @light_ids
       }
 
-      uri = URI.parse("http://#{@bridge.ip}/api/#{@client.username}/groups")
-      http = Net::HTTP.new(uri.host)
+      uri = URI.parse("https://#{@bridge.ip}/api/#{@client.username}/groups")
+      http = HttpClient.create(uri)
       response = http.request_post(uri.path, JSON.dump(body))
       json = JSON(response.body)
 
@@ -132,7 +134,7 @@ module Hue
 
     def destroy!
       uri = URI.parse(base_url)
-      http = Net::HTTP.new(uri.host)
+      http = HttpClient.create(uri)
       response = http.delete(uri.path)
       json = JSON(response.body)
       @id = nil if json[0]["success"]
@@ -173,7 +175,7 @@ module Hue
     end
 
     def base_url
-      "http://#{@bridge.ip}/api/#{@client.username}/groups/#{id}"
+      "https://#{@bridge.ip}/api/#{@client.username}/groups/#{id}"
     end
   end
 end

--- a/lib/hue/http_client.rb
+++ b/lib/hue/http_client.rb
@@ -1,0 +1,12 @@
+# Helper module for creating HTTPS connections to the Hue Bridge.
+# The Hue Bridge uses a self-signed certificate, so we disable verification.
+module Hue
+  module HttpClient
+    def self.create(uri)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http
+    end
+  end
+end

--- a/lib/hue/light.rb
+++ b/lib/hue/light.rb
@@ -107,7 +107,7 @@ module Hue
       }
 
       uri = URI.parse(base_url)
-      http = Net::HTTP.new(uri.host)
+      http = HttpClient.create(uri)
       response = http.request_put(uri.path, JSON.dump(body))
       response = JSON(response.body).first
       if response["success"]
@@ -135,14 +135,16 @@ module Hue
       body[:transitiontime] = transition if transition
 
       uri = URI.parse("#{base_url}/state")
-      http = Net::HTTP.new(uri.host)
+      http = HttpClient.create(uri)
       response = http.request_put(uri.path, JSON.dump(body))
       JSON(response.body)
     end
 
     # Refresh the state of the lamp
     def refresh
-      json = JSON(Net::HTTP.get(URI.parse(base_url)))
+      uri = URI.parse(base_url)
+      http = HttpClient.create(uri)
+      json = JSON(http.get(uri.path).body)
       unpack(json)
     end
 
@@ -180,7 +182,7 @@ module Hue
     end
 
     def base_url
-      "http://#{@bridge.ip}/api/#{@client.username}/lights/#{id}"
+      "https://#{@bridge.ip}/api/#{@client.username}/lights/#{id}"
     end
   end
 end

--- a/lib/hue/scene.rb
+++ b/lib/hue/scene.rb
@@ -42,7 +42,7 @@ module Hue
     end
 
     def base_url
-      "http://#{@bridge.ip}/api/#{@client.username}/scenes/#{id}"
+      "https://#{@bridge.ip}/api/#{@client.username}/scenes/#{id}"
     end
   end
 end

--- a/test/hue/client_test.rb
+++ b/test/hue/client_test.rb
@@ -7,9 +7,9 @@ class ClientTest < Minitest::Test
     stub_request(:get, "https://discovery.meethue.com/")
       .to_return(body: '[{"id":"ffa57b3b257200065704","internalipaddress":"192.168.0.1"},{"id":"63c2fc01391276a319f9","internalipaddress":"192.168.0.2"}]')
 
-    stub_request(:post, "http://192.168.0.1/api").to_return(body: '[{"success":{"username":"ruby"}}]')
-    stub_request(:get, %r{http://192.168.0.1/api/*}).to_return(body: '[{"success":true}]')
-    stub_request(:get, %r{http://192.168.0.2/api/*}).to_return(body: '[{"success":true}]')
+    stub_request(:post, "https://192.168.0.1/api").to_return(body: '[{"success":{"username":"ruby"}}]')
+    stub_request(:get, %r{https://192.168.0.1/api/*}).to_return(body: '[{"success":true}]')
+    stub_request(:get, %r{https://192.168.0.2/api/*}).to_return(body: '[{"success":true}]')
   end
 
   def test_with_bridge_id

--- a/test/hue/light_test.rb
+++ b/test/hue/light_test.rb
@@ -7,9 +7,9 @@ class LightTest < Minitest::Test
     stub_request(:get, "https://discovery.meethue.com/")
       .to_return(body: '[{"internalipaddress":"localhost"}]')
 
-    stub_request(:get, %r{http://localhost/api/*}).to_return(body: '[{"success":true}]')
-    stub_request(:post, "http://localhost/api").to_return(body: '[{"success":{"username":"ruby"}}]')
-    stub_request(:put, %r{http://localhost/api*}).to_return(body: "[{}]")
+    stub_request(:get, %r{https://localhost/api/*}).to_return(body: '[{"success":true}]')
+    stub_request(:post, "https://localhost/api").to_return(body: '[{"success":{"username":"ruby"}}]')
+    stub_request(:put, %r{https://localhost/api*}).to_return(body: "[{}]")
   end
 
   %w[on hue saturation brightness color_temperature alert effect].each do |attribute|
@@ -18,7 +18,7 @@ class LightTest < Minitest::Test
       light = Hue::Light.new(client, client.bridge, 0, {"state" => {}})
 
       light.send(:"#{attribute}=", 24)
-      assert_requested :put, %r{http://localhost/api/.*/lights/0}
+      assert_requested :put, %r{https://localhost/api/.*/lights/0}
     end
   end
 
@@ -28,7 +28,7 @@ class LightTest < Minitest::Test
     assert_equal false, light.on?
 
     light.toggle!
-    assert_requested :put, %r{http://localhost/api/.*/lights/0}
+    assert_requested :put, %r{https://localhost/api/.*/lights/0}
     assert_equal true, light.on?
   end
 
@@ -38,7 +38,7 @@ class LightTest < Minitest::Test
     assert_equal true, light.on?
 
     light.toggle!
-    assert_requested :put, %r{http://localhost/api/.*/lights/0}
+    assert_requested :put, %r{https://localhost/api/.*/lights/0}
     assert_equal false, light.on?
   end
 end


### PR DESCRIPTION
The new Hue Bridge Pro does not support HTTP, only HTTPS which breaks the gem. I changed all HTTP calls to HTTPS calls (without cert verification). 